### PR TITLE
Right-associative :|, proper tests and PureScript 0.8 updates

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,5 +13,8 @@
   "dependencies": {
     "purescript-console": "^0.1.0",
     "purescript-foldable-traversable": "^0.4.0"
+  },
+  "dev-dependencies": {
+    "purescript-assert": "^0.1.0"
   }
 }

--- a/docs/Data/NonEmpty.md
+++ b/docs/Data/NonEmpty.md
@@ -29,6 +29,22 @@ nonEmptyList = 0 :| empty
 (Traversable f) => Traversable (NonEmpty f)
 ```
 
+#### `nonEmpty`
+
+``` purescript
+nonEmpty :: forall f a. a -> f a -> NonEmpty f a
+```
+
+#### `(:|)`
+
+``` purescript
+infixr 5 nonEmpty as :|
+```
+
+_right-associative / precedence 5_
+
+An infix synonym for `NonEmpty`.
+
 #### `singleton`
 
 ``` purescript
@@ -36,16 +52,6 @@ singleton :: forall f a. (Plus f) => a -> NonEmpty f a
 ```
 
 Create a non-empty structure with a single value.
-
-#### `(:|)`
-
-``` purescript
-(:|) :: forall f a. a -> f a -> NonEmpty f a
-```
-
-_non-associative / precedence 5_
-
-An infix synonym for `NonEmpty`.
 
 #### `foldl1`
 

--- a/src/Data/NonEmpty.purs
+++ b/src/Data/NonEmpty.purs
@@ -4,6 +4,7 @@
 module Data.NonEmpty
   ( NonEmpty(..)
   , singleton
+  , nonEmpty
   , (:|)
   , foldl1
   , foldMap1
@@ -17,11 +18,11 @@ module Data.NonEmpty
 import Prelude
 
 import Control.Alt ((<|>))
-import Control.Alternative (Alternative)
-import Control.Plus (Plus, empty)
+import Control.Alternative (class Alternative)
+import Control.Plus (class Plus, empty)
 
-import Data.Foldable (Foldable, foldl, foldr, foldMap)
-import Data.Traversable (Traversable, traverse, sequence)
+import Data.Foldable (class Foldable, foldl, foldr, foldMap)
+import Data.Traversable (class Traversable, traverse, sequence)
 
 -- | A non-empty container of elements of type a.
 -- |
@@ -33,15 +34,15 @@ import Data.Traversable (Traversable, traverse, sequence)
 -- | ```
 data NonEmpty f a = NonEmpty a (f a)
 
-infix 5 :|
+nonEmpty :: forall f a. a -> f a -> NonEmpty f a
+nonEmpty = NonEmpty
+
+-- | An infix synonym for `NonEmpty`.
+infixr 5 nonEmpty as :|
 
 -- | Create a non-empty structure with a single value.
 singleton :: forall f a. (Plus f) => a -> NonEmpty f a
 singleton a = NonEmpty a empty
-
--- | An infix synonym for `NonEmpty`.
-(:|) :: forall f a. a -> f a -> NonEmpty f a
-(:|) = NonEmpty
 
 -- | Fold a non-empty structure, collecting results using a binary operation.
 foldl1 :: forall f a. (Foldable f) => (a -> a -> a) -> NonEmpty f a -> a

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,12 +2,24 @@ module Test.Main where
 
 import Prelude
 
-import Data.Maybe
-import Data.NonEmpty
+import Control.Monad.Eff (Eff)
+import Data.Foldable (fold, foldl)
+import Data.Maybe (Maybe(..))
+import Data.NonEmpty (NonEmpty(), (:|), fold1, foldl1, oneOf, head, tail, singleton)
+import Test.Assert (ASSERT, assert)
 
-import Control.Monad.Eff.Console
+type AtLeastTwo f a = NonEmpty (NonEmpty f) a
 
+second :: forall f a. AtLeastTwo f a -> a
+second = tail >>> head
+
+main :: Eff (assert :: ASSERT) Unit
 main = do
-  print $ fold1 ("Hello" :| [" ", "World"])
-  print $ 0 :| Nothing
-  print (0 :| Nothing == 0 :| Just 1)
+  assert $ singleton 0 == 0 :| []
+  assert $ 0 :| Nothing /= 0 :| Just 1
+  assert $ foldl1 (+) (1 :| [2, 3]) == 6
+  assert $ foldl (+) 0 (1 :| [2, 3]) == 6
+  assert $ fold1 ("Hello" :| [" ", "World"]) == "Hello World"
+  assert $ fold ("Hello" :| [" ", "World"]) == "Hello World"
+  assert $ oneOf (0 :| Nothing) == oneOf (0 :| Just 1)
+  assert $ second (1 :| 2 :| [3, 4]) == 2


### PR DESCRIPTION
This PR includes a few things:
- Updates for PureScript 0.8 (fix warnings and use new operator alias syntax)
- Make `:|` right-associative
- Add test suite (previously, Test.Main just printed a few things to the console)

If you would prefer a PureScript 0.7 - compatible PR, let me know.

Remark: it's slightly unfortunate that we have to (?) define a synonym `nonEmpty = NonEmpty` in order to define the operator `:|`. It would be nice if we could use:

``` purescript
infixr 6 NonEmpty as :|
```
