### PR TITLE
Add Extend and Comonad instances

### DIFF
--- a/src/Data/NonEmpty.purs
+++ b/src/Data/NonEmpty.purs
@@ -18,6 +18,8 @@ import Prelude
 
 import Control.Alt ((<|>))
 import Control.Alternative (class Alternative)
+import Control.Comonad (class Comonad)
+import Control.Extend (class Extend)
 import Control.Plus (class Plus, empty)
 
 import Data.Foldable (class Foldable, foldl, foldr, foldMap)
@@ -83,6 +85,13 @@ derive instance genericNonEmpty :: (Generic (f a), Generic a) => Generic (NonEmp
 
 instance functorNonEmpty :: Functor f => Functor (NonEmpty f) where
   map f (a :| fa) = f a :| map f fa
+
+instance extendNonEmpty :: (Functor f, Plus f) => Extend (NonEmpty f) where
+  extend f (a :| fa) =
+    NonEmpty (f (NonEmpty a empty)) (map (\x -> f (NonEmpty x empty)) fa)
+
+instance comonadNonEmpty :: (Functor f, Plus f) => Comonad (NonEmpty f) where
+  extract (a :| _) = a
 
 instance foldableNonEmpty :: Foldable f => Foldable (NonEmpty f) where
   foldMap f (a :| fa) = f a <> foldMap f fa


### PR DESCRIPTION
Just throwing this out there - the `Extend` instance is a little bonkers, so we can just close this if it seems nonsensical.

I feel like the `Extend` instance really should operate on each subset of the thing, so if it was a `1 :| [2, 3, 4]` it would call `f` on `1 :| [2, 3, 4]`, `2 :| [3, 4]`, `3 :| [4]`, `4 :| []`, but unless we invented some kind of `Unconsable` class I don't think there's a way of expressing that. Given that, `extend` operates on every element with an empty tail instead ¯_(ツ)_/¯.

edit: I went with `Plus` as the constraint since elsewhere we prefer `Alternative` over `Monoid` classes.
