### PR TITLE
Add `hmap`

### DIFF
--- a/src/Data/NonEmpty.purs
+++ b/src/Data/NonEmpty.purs
@@ -71,6 +71,9 @@ head (x :| _) = x
 tail :: forall f a. NonEmpty f a -> f a
 tail (_ :| xs) = xs
 
+hmap :: forall f g. (f ~> g) -> NonEmpty f ~> NonEmpty g
+hmap f (a :| as) = (a :| f as)
+
 instance showNonEmpty :: (Show a, Show (f a)) => Show (NonEmpty f a) where
   show (a :| fa) = "(NonEmpty " <> show a <> " " <> show fa <> ")"
 


### PR DESCRIPTION
Useful for changing the type of the underlying collection.
The 'h' in "hmap" is for higher-order.

I could also easily be convinced to use the name hoist: http://hackage.haskell.org/package/mmorph-1.1.2/docs/Control-Monad-Morph.html#v:hoist.