### PR TITLE
Deprecate monomorphic foldl1

### DIFF
--- a/src/Data/NonEmpty.purs
+++ b/src/Data/NonEmpty.purs
@@ -49,7 +49,7 @@ singleton :: forall f a. Plus f => a -> NonEmpty f a
 singleton a = a :| empty
 
 -- | Fold a non-empty structure, collecting results using a binary operation.
-foldl1 :: forall f a. Foldable f => Warn (Text "'foldl1' is deprecated") => (a -> a -> a) -> NonEmpty f a -> a
+foldl1 :: forall f a. Foldable f => Warn (Text "'Data.NonEmpty.foldl1' is deprecated, use 'Data.Semigroup.Foldable.foldl1' instead") => (a -> a -> a) -> NonEmpty f a -> a
 foldl1 = Foldable1.foldl1
 
 fromNonEmpty :: forall f a r. (a -> f a -> r) -> NonEmpty f a -> r

--- a/src/Data/NonEmpty.purs
+++ b/src/Data/NonEmpty.purs
@@ -23,11 +23,13 @@ import Data.FunctorWithIndex (class FunctorWithIndex, mapWithIndex)
 import Data.Maybe (Maybe(..), maybe)
 import Data.Ord (class Ord1)
 import Data.Semigroup.Foldable (class Foldable1, foldMap1)
+import Data.Semigroup.Foldable (foldl1) as Foldable1
 import Data.Traversable (class Traversable, traverse, sequence)
 import Data.TraversableWithIndex (class TraversableWithIndex, traverseWithIndex)
 import Data.Tuple (uncurry)
 import Data.Unfoldable (class Unfoldable, unfoldr)
 import Data.Unfoldable1 (class Unfoldable1)
+import Prim.TypeError (class Warn, Text)
 
 -- | A non-empty container of elements of type a.
 -- |
@@ -47,8 +49,8 @@ singleton :: forall f a. Plus f => a -> NonEmpty f a
 singleton a = a :| empty
 
 -- | Fold a non-empty structure, collecting results using a binary operation.
-foldl1 :: forall f a. Foldable f => (a -> a -> a) -> NonEmpty f a -> a
-foldl1 f (a :| fa) = foldl f a fa
+foldl1 :: forall f a. Foldable f => Warn (Text "'foldl1' is deprecated") => (a -> a -> a) -> NonEmpty f a -> a
+foldl1 = Foldable1.foldl1
 
 fromNonEmpty :: forall f a r. (a -> f a -> r) -> NonEmpty f a -> r
 fromNonEmpty f (a :| fa) = a `f` fa
@@ -108,7 +110,7 @@ instance foldable1NonEmpty :: Foldable f => Foldable1 (NonEmpty f) where
   fold1 = foldMap1 identity
   foldMap1 f (a :| fa) = foldl (\s a1 -> s <> f a1) (f a) fa
   foldr1 f (a :| fa) = maybe a (f a) $ foldr (\a1 -> Just <<< maybe a1 (f a1)) Nothing fa
-  foldl1 = foldl1
+  foldl1 f (a :| fa) = foldl f a fa
 
 instance unfoldable1NonEmpty :: Unfoldable f => Unfoldable1 (NonEmpty f) where
   unfoldr1 f b = uncurry (:|) $ unfoldr (map f) <$> f b


### PR DESCRIPTION
Responses to https://github.com/purescript/purescript-nonempty/pull/40 seem more favorable to deprecating then removing  `Data.NonEmpty.foldl1`.