### PR TITLE
Remove deprecation warning on monomorphic fold1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ New features:
 Bugfixes:
 
 Other improvements:
+- Drop deprecation warning on `fold1` (#45 by @JordanMartinez)
 
 ## [v6.1.0](https://github.com/purescript/purescript-nonempty/releases/tag/v6.0.0) - 2021-10-21
 

--- a/src/Data/NonEmpty.purs
+++ b/src/Data/NonEmpty.purs
@@ -29,7 +29,6 @@ import Data.TraversableWithIndex (class TraversableWithIndex, traverseWithIndex)
 import Data.Tuple (uncurry)
 import Data.Unfoldable (class Unfoldable, unfoldr)
 import Data.Unfoldable1 (class Unfoldable1)
-import Prim.TypeError (class Warn, Text)
 
 -- | A non-empty container of elements of type a.
 -- |
@@ -70,12 +69,10 @@ singleton a = a :| empty
 
 -- | Fold a non-empty structure, collecting results using a binary operation.
 -- |
--- | Deprecated, use 'Data.Semigroup.Foldable.foldl1' instead
--- |
 -- | ```purescript
 -- | foldl1 (+) (1 :| [2, 3]) == 6
 -- | ```
-foldl1 :: forall f a. Foldable f => Warn (Text "'Data.NonEmpty.foldl1' is deprecated, use 'Data.Semigroup.Foldable.foldl1' instead") => (a -> a -> a) -> NonEmpty f a -> a
+foldl1 :: forall f a. Foldable f => (a -> a -> a) -> NonEmpty f a -> a
 foldl1 = Foldable1.foldl1
 
 -- | Apply a function that takes the `first` element and remaining elements


### PR DESCRIPTION
While this was originally deprecated in #42, `purescript-arrays` and `purescript-lists` are exporting monomorphic versions of `fold`/`fold1`. So, we are removing the deprecation notice here to keep things consistent. See [Harry's comment](https://github.com/purescript/purescript-arrays/pull/201#issuecomment-752676699) for more context﻿
