### PR TITLE
Add Semigroup instance for NonEmpty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
-- Added semigroup instance (#18)
+- Added semigroup instance (#18 by @jmatsushita)
 
 Bugfixes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project are documented in this file. The format is based
 Breaking changes:
 
 New features:
+- Added semigroup instance (#18)
 
 Bugfixes:
 

--- a/src/Data/NonEmpty.purs
+++ b/src/Data/NonEmpty.purs
@@ -167,3 +167,8 @@ instance foldable1NonEmpty :: Foldable f => Foldable1 (NonEmpty f) where
 
 instance unfoldable1NonEmpty :: Unfoldable f => Unfoldable1 (NonEmpty f) where
   unfoldr1 f b = uncurry (:|) $ unfoldr (map f) <$> f b
+
+instance semigroupNonEmpty
+  :: (Applicative f, Semigroup (f a))
+  => Semigroup (NonEmpty f a) where
+  append (a1 :| f1) (a2 :| f2) = a1 :| (f1 <> pure a2 <> f2)

--- a/src/Data/NonEmpty.purs
+++ b/src/Data/NonEmpty.purs
@@ -168,6 +168,9 @@ instance foldable1NonEmpty :: Foldable f => Foldable1 (NonEmpty f) where
 instance unfoldable1NonEmpty :: Unfoldable f => Unfoldable1 (NonEmpty f) where
   unfoldr1 f b = uncurry (:|) $ unfoldr (map f) <$> f b
 
+-- | For `Semigroup` we don't know for sure that `pure` will behave sensibly 
+-- | alongside `<>` because we don't have any laws which govern their
+-- | behaviour, in practice, with Array, List, it should behave sensibly.
 instance semigroupNonEmpty
   :: (Applicative f, Semigroup (f a))
   => Semigroup (NonEmpty f a) where

--- a/src/Data/NonEmpty.purs
+++ b/src/Data/NonEmpty.purs
@@ -168,9 +168,9 @@ instance foldable1NonEmpty :: Foldable f => Foldable1 (NonEmpty f) where
 instance unfoldable1NonEmpty :: Unfoldable f => Unfoldable1 (NonEmpty f) where
   unfoldr1 f b = uncurry (:|) $ unfoldr (map f) <$> f b
 
--- | For `Semigroup` we don't know for sure that `pure` will behave sensibly 
--- | alongside `<>` because we don't have any laws which govern their
--- | behaviour, in practice, with Array, List, it should behave sensibly.
+-- | This is a lawful `Semigroup` instance that will behave sensibly for common nonempty
+-- | containers like lists and arrays. However, it's not guaranteed that `pure` will behave
+-- | sensibly alongside `<>` for all types, as we don't have any laws which govern their behavior.
 instance semigroupNonEmpty
   :: (Applicative f, Semigroup (f a))
   => Semigroup (NonEmpty f a) where

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -27,3 +27,4 @@ main = do
   assert $ oneOf (0 :| Nothing) == oneOf (0 :| Just 1)
   assert $ second (1 :| 2 :| [3, 4]) == 2
   assert $ U1.range 0 9 == (0 :| [1, 2, 3, 4, 5, 6, 7, 8, 9])
+  assert $ (0 :| [1,2]) <> (3 :| [4,5]) == (0 :| [1, 2, 3, 4, 5])


### PR DESCRIPTION
**Description of the change**

Adding a Semigroup instance for NonEmpty (arrays and lists) as per #18 based on @asturtz2 contribution.

---

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a reference to this PR (e.g. "- Made a change (#0000)")
- [x] Linked any existing issues or proposals that this pull request should close
- [x] Updated or added relevant documentation
- [x] Added a test for the contribution (if applicable)
